### PR TITLE
Optimise the VS Code container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 
 	"hostRequirements": {
-	   "cpus": 8
+	   "cpus": 4
 	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,8 @@
 	// The 'service' property is the name of the service for the container that VS Code should
 	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
 	"service": "code",
+
+	"overrideCommand": true,
 	
 	// The optional 'workspaceFolder' property is the path VS Code should open by default when
 	// connected. This is typically a file mount in .devcontainer/docker-compose.yml

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,5 @@
 version: '3'
 services:
    code:
-    # See https://github.com/devcontainers/images/tree/main/src/universal
-    image: mcr.microsoft.com/devcontainers/base:bullseye
+    # See https://github.com/devcontainers/images
+    image: mcr.microsoft.com/devcontainers/base:alpine

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,5 @@
 version: '3'
 services:
    code:
-    # See https://github.com/devcontainers/images/tree/main/src/python
-    image: mcr.microsoft.com/devcontainers/python:3
+    # See https://github.com/devcontainers/images/tree/main/src/base-alpine
+    image: mcr.microsoft.com/devcontainers/base:alpine

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -2,4 +2,4 @@ version: '3'
 services:
    code:
     # See https://github.com/devcontainers/images/tree/main/src/universal
-    image: mcr.microsoft.com/devcontainers/universal:linux
+    image: mcr.microsoft.com/devcontainers/base:bullseye

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,5 @@
 version: '3'
 services:
    code:
-    # See https://github.com/devcontainers/images/tree/main/src/universal
-    image: mcr.microsoft.com/devcontainers/universal:linux
+    # See https://github.com/devcontainers/images/tree/main/src/python
+    image: mcr.microsoft.com/devcontainers/python:3

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,5 @@
 version: '3'
 services:
    code:
-    # See https://github.com/devcontainers/images/tree/main/src/base-alpine
-    image: mcr.microsoft.com/devcontainers/base:alpine
+    # See https://github.com/devcontainers/images/tree/main/src/universal
+    image: mcr.microsoft.com/devcontainers/universal:linux

--- a/product/Dockerfile
+++ b/product/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3-onbuild
+RUN echo foobarbaz
 RUN brokenbrokenbroken
 COPY . /usr/src/app
 CMD ["python", "api.py"]

--- a/product/Dockerfile
+++ b/product/Dockerfile
@@ -1,3 +1,4 @@
 FROM python:3-onbuild
+RUN brokenbrokenbroken
 COPY . /usr/src/app
 CMD ["python", "api.py"]

--- a/product/Dockerfile
+++ b/product/Dockerfile
@@ -1,5 +1,3 @@
 FROM python:3-onbuild
-RUN echo foobarbaz
-RUN brokenbrokenbroken
 COPY . /usr/src/app
 CMD ["python", "api.py"]


### PR DESCRIPTION

- Use `mcr.microsoft.com/devcontainers/base:alpine` instead of `universal`
  - This image contains Git but doesn't contain all of the languages
- "overrideCommand": true
  - This runs a command that keeps the VS Code container alive
  - The `universal` has this build in but `base:alpine` doesn't
  - `overrideCommand` defaults to `false` when using Docker Compose
- "cpus": 4
  - Changing to `base:alpine` means we can use a smaller codspace